### PR TITLE
Support converting blocks with type of list.

### DIFF
--- a/src/Caouecs/Sirtrevorjs/Converter/TextConverter.php
+++ b/src/Caouecs/Sirtrevorjs/Converter/TextConverter.php
@@ -33,6 +33,7 @@ class TextConverter extends BaseConverter implements ConverterInterface
         "quote",
         "blockquote",
         "heading",
+        "list",
     ];
 
     /**
@@ -110,5 +111,15 @@ class TextConverter extends BaseConverter implements ConverterInterface
     public function quoteToHtml()
     {
         return $this->blockquoteToHtml();
+    }
+
+	/**
+     * Converts list to html.
+     *
+     * @return string
+     */
+    public function listToHtml()
+    {
+        return $this->textToHtml();
     }
 }

--- a/src/Caouecs/Sirtrevorjs/SirTrevorJsConverter.php
+++ b/src/Caouecs/Sirtrevorjs/SirTrevorJsConverter.php
@@ -40,6 +40,7 @@ class SirTrevorJsConverter
         "text"          => "Text",
         "tweet"         => "Social",
         "video"         => "Video",
+        "list"          => "Text",
     ];
 
     /**


### PR DESCRIPTION
I noticed that the type "list" is not supported yet, this is one of sir-trevors default blocks.

Luckily the created data is compatible with parsedown so only a simple change was needed to let the Text converter handle this block.