### PR TITLE
Convert Markdown in Headings

### DIFF
--- a/src/Caouecs/Sirtrevorjs/Converter/TextConverter.php
+++ b/src/Caouecs/Sirtrevorjs/Converter/TextConverter.php
@@ -84,7 +84,7 @@ class TextConverter extends BaseConverter implements ConverterInterface
     public function headingToHtml()
     {
         return $this->view("text.heading", [
-            "text" => $this->data['text'],
+            "text" => $this->markdown->text($this->data['text']),
         ]);
     }
 


### PR DESCRIPTION
It's possible to use styles like bold and italic (and even links!) in headings, so make sure markdown converts headings too.